### PR TITLE
Update GraphQL query to get all required data

### DIFF
--- a/tests/gatsby-starter-default/src/pages/index.js
+++ b/tests/gatsby-starter-default/src/pages/index.js
@@ -22,6 +22,7 @@ query IndexPageQuery {
         node {
           id
           title
+          description
         }
       }
     }


### PR DESCRIPTION
In `tests/gatsby-starter-default`, the index page illustrates the using GraphQL query after creating nodes using gatsby-source-plone. In the component, `node.description` is used but in the query, it's not specified and so it is not displayed. 

I've updated the query to retrieve all required data.