### PR TITLE
Use baseUrl instead of hardcoded string

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -22,7 +22,7 @@ exports.sourceNodes = function () {
           case 0:
             createNode = boundActionCreators.createNode;
             _context2.next = 3;
-            return axios.get("http://localhost:8080/Plone/@search", {
+            return axios.get(baseUrl + "/@search", {
               params: {
                 metadata_fields: "_all"
               },

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -7,7 +7,7 @@ exports.sourceNodes = async(
 ) => {
   const { createNode } = boundActionCreators;
 
-  const data = await axios.get("http://localhost:8080/Plone/@search", {
+  const data = await axios.get(`${baseUrl}/@search`, {
     params: {
       metadata_fields: "_all"
     },

--- a/tests/gatsby-starter-default/gatsby-config.js
+++ b/tests/gatsby-starter-default/gatsby-config.js
@@ -4,7 +4,8 @@ module.exports = {
   },
   plugins: [
     {
-      resolve: 'gatsby-source-plone'
+      resolve: `gatsby-source-plone`,
+      options: { baseUrl: `http://localhost:8080/Plone/` },
     },
     `gatsby-plugin-react-helmet`
   ]


### PR DESCRIPTION
Instead of using "http://localhost:8080/Plone/@search", the `baseUrl` set from `gatsby-config.js` is used. This illustrates the use of the `options` variable in plugins, allowing you to set use URL you specify in Gatsby as the Plone source. 