### PR TITLE
Added Prettier config to editor

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "trailingComma": "es5",
+  "singleQuote": true
+}

--- a/Makefile
+++ b/Makefile
@@ -33,12 +33,6 @@ stop:
 test: node_modules
 	make -C tests/gatsby-starter-default
 
-.PHONY: prettier
-prettier: node_modules
-	prettier --write --trailing-comma es5 --single-quote \
-	  $$(find src -name "*.js")
-	make -C tests/gatsby-starter-default prettier
-
 tests/gatsby-starter-default/public: $(SOURCES)
 	make -C tests/gatsby-starter-default clean build
 

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Pulls data from Plone sites with
 // In your gatsby-config.js
 plugins: [
   {
-    resolve: `gatsby-source-plone`
-  }
+    resolve: `gatsby-source-plone`,
+  },
 ];
 ```
 
@@ -107,3 +107,15 @@ make test
 ```
 
 This command will automatically fire up the Plone backend, build and start Gatsby and the execute the selenium-based acceptance tests.
+
+### Prettier Configuration
+
+This project uses Prettier for code formatting, the `.prettierrc` file contains the requisite custom settings the project
+
+It's recommended that you setup _Format on Save_ so that your editor takes care of this automatically for you. In [Visual Studio Code](https://code.visualstudio.com/) this can be setup in project by adding the following to your Workspace settings (or in `.vscode/settings.json`):
+
+```json
+{
+  "editor.formatOnSave": true
+}
+```

--- a/tests/gatsby-starter-default/.prettierrc
+++ b/tests/gatsby-starter-default/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "trailingComma": "es5",
+  "singleQuote": true
+}

--- a/tests/gatsby-starter-default/Makefile
+++ b/tests/gatsby-starter-default/Makefile
@@ -48,12 +48,6 @@ test: clean build pyvenv
 	  kill $$pid; \
 	  exit $$status
 
-.PHONY: prettier
-prettier: node_modules
-	prettier --write --trailing-comma es5 --single-quote \
-	  $$(find src -name "*.js")
-	prettier --write $$(find src -name "*.css")
-
 public: node_modules $(SOURCES)
 	docker-compose up -d
 	while ! $$($(HTTP_GET) http://localhost:8080/); do sleep 1; done


### PR DESCRIPTION
Addresses task 3 of #24 

Setup `.prettierrc` for editors to follow and also added documentation in readme to set it up with Visual Studio Code. As per slack discussion with @datakurre , do mention if any changes are required.

cc @cekk 
This ensures that code is auto formatted by Prettier on save. 