### PR TITLE
Restore 'prettier' make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,11 @@ purge: clean
 	$(RM) -r node_modules
 	make -C tests/gatsby-starter-default purge
 
+.PHONY: prettier
+prettier: node_modules
+	prettier --write $$(find src -name "*.js")
+	make -C tests/gatsby-starter-default prettier
+
 .PHONY: develop
 develop:
 	make -C tests/gatsby-starter-default develop

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -1,20 +1,18 @@
-import axios from "axios";
-import crypto from "crypto";
+import axios from 'axios';
+import crypto from 'crypto';
 
 // Helper to create content digest
 const createContentDigest = item =>
   crypto
-  .createHash(`md5`)
-  .update(JSON.stringify(item))
-  .digest(`hex`);
+    .createHash(`md5`)
+    .update(JSON.stringify(item))
+    .digest(`hex`);
 
 // Helper to get data from url
 const fetchData = async url => {
-  const {
-    data
-  } = await axios.get(url, {
+  const { data } = await axios.get(url, {
     headers: {
-      accept: "application/json"
+      accept: 'application/json',
     },
     params: {
       metadata_fields: '_all',
@@ -23,18 +21,11 @@ const fetchData = async url => {
   return data;
 };
 
-exports.sourceNodes = async ({
-  boundActionCreators,
-  getNode,
-  hasNodeChanged,
-  store,
-  cache
-}, {
-  baseUrl
-}) => {
-  const {
-    createNode
-  } = boundActionCreators;
+exports.sourceNodes = async (
+  { boundActionCreators, getNode, hasNodeChanged, store, cache },
+  { baseUrl }
+) => {
+  const { createNode } = boundActionCreators;
 
   const data = await fetchData(`${baseUrl}/@search`);
 
@@ -42,12 +33,12 @@ exports.sourceNodes = async ({
     let node = {
       ...item,
       internal: {
-        type: item["@type"].replace(" ", ""),
+        type: item['@type'].replace(' ', ''),
         contentDigest: createContentDigest(item),
-        mediaType: "text/html"
-      }
+        mediaType: 'text/html',
+      },
     };
-    node.id = item["@id"];
+    node.id = item['@id'];
     node.parent = null;
     node.children = [];
     createNode(node);

--- a/tests/gatsby-starter-default/Makefile
+++ b/tests/gatsby-starter-default/Makefile
@@ -31,6 +31,11 @@ develop: node_modules pyvenv
 	docker-compose up -d
 	gatsby develop
 
+.PHONY: prettier
+prettier: node_modules
+	prettier --write $$(find src -name "*.js")
+	prettier --write --single-quote false $$(find src -name "*.css")
+
 .PHONY: serve
 serve: node_modules public
 	gatsby serve


### PR DESCRIPTION
@ajayns We had miscommunication about "prettier" in Makefile. It was good to move configuration into .prettierrc, but the make target should remain so that prettier can be executed without editor configuration.