### PR TITLE
'File' Node Type conflict fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ You can query nodes created from Plone like the following:
 
 ```graphql
 {
-  allNewsItem {
+  allPloneNewsItem {
     edges {
       node {
         title

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -38,7 +38,6 @@ exports.sourceNodes = async (
         mediaType: 'text/html',
       },
     };
-    console.log(node.internal.type);
     node.id = item['@id'];
     node.parent = null;
     node.children = [];

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -33,11 +33,12 @@ exports.sourceNodes = async (
     let node = {
       ...item,
       internal: {
-        type: item['@type'].replace(' ', ''),
+        type: `Plone${item['@type'].replace(' ', '')}`,
         contentDigest: createContentDigest(item),
         mediaType: 'text/html',
       },
     };
+    console.log(node.internal.type);
     node.id = item['@id'];
     node.parent = null;
     node.children = [];

--- a/tests/gatsby-starter-default/src/pages/index.js
+++ b/tests/gatsby-starter-default/src/pages/index.js
@@ -3,7 +3,7 @@ import Link from 'gatsby-link';
 
 const IndexPage = ({ data }) => (
   <div>
-    {data.allDocument.edges.map(({ node }) => (
+    {data.allPloneDocument.edges.map(({ node }) => (
       <div>
         <h3>{node.title}</h3>
         <h4>{node.description}</h4>
@@ -17,7 +17,7 @@ export default IndexPage;
 // Set here the ID of the home page.
 export const pageQuery = graphql`
   query IndexPageQuery {
-    allDocument {
+    allPloneDocument {
       edges {
         node {
           id


### PR DESCRIPTION
References #21 

In discussion, we've decided the best method would be to prepend `Plone` to all the node types which would prevent the name clash of `File` which is a node type owned by `gatsby-source-filesystem`. Also, [discussed](https://github.com/gatsbyjs/gatsby/issues/5182) with the Gatsby community about the best approach, and this is what we came up with. 