### PR TITLE
Update npmignore, scripts

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -37,3 +37,14 @@ public/
 .vscode/
 
 .serverless/
+
+
+# Config
+.editorconfig
+.prettierrc
+.travis.yml
+Makefile
+shell.nix
+
+# Tests
+jest.config.js

--- a/package.json
+++ b/package.json
@@ -29,9 +29,9 @@
     ]
   },
   "scripts": {
-    "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
-    "prepublish": "cross-env NODE_ENV=production npm run build",
+    "build": "babel src --out-dir . --ignore '**/__tests__/'",
+    "watch": "babel -w src --out-dir . --ignore '**/__tests__/'",
+    "prepare": "cross-env NODE_ENV=production npm run build",
     "test": "jest"
   },
   "repository": {


### PR DESCRIPTION
Babel was noticed not ignore the `__tests__` folder so I had to come up with a workaround for this. Also npm has deprecated `prepublish` scripts so it's updated to `prepare`.
