### PR TITLE
Add configuration option for default image scale

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -7,13 +7,13 @@ pkgs.stdenv.mkDerivation rec {
     jq
     lcms2
     libpng
-    nodejs-9_x
+    nodejs-10_x
     pkgconfig
     python3
     travis
     zlib
     (yarn.override {
-      nodejs = nodejs-9_x;
+      nodejs = nodejs-10_x;
     })
   ];
   shellHook = ''

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -378,7 +378,7 @@ exports.sourceNodes = async (
 // Expand file and image attributes into linked remote file nodes
 exports.onCreateNode = async (
   { node, actions, cache, store },
-  { baseUrl, token, logLevel }
+  { baseUrl, token, imageScale, logLevel }
 ) => {
   const logger = logging.getLogger(logging[logLevel] || 100);
   if (
@@ -420,10 +420,12 @@ exports.onCreateNode = async (
     };
 
     if (node.image) {
-      logger.info(`Fetching file – ${node.id.replace(baseUrl, '') || '/'}`);
+      logger.info(`Fetching image – ${node.id.replace(baseUrl, '') || '/'}`);
       try {
         const imageNode = await createRemoteFileNode({
-          url: node.image.download,
+          url: imageScale
+            ? `${node.image.download}/${imageScale}`
+            : node.image.download,
           store,
           cache,
           createNode: createImageNode,

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -242,7 +242,7 @@ exports.sourceNodes = async (
           createNode(node);
         }
       } catch (e) {
-        logger.error(`Skipping node – ${item._id.replace(baseUrl, '')} (${e})`)
+        logger.error(`Skipping node – ${item._id.replace(baseUrl, '')} (${e})`);
       }
     }
   } else {

--- a/src/utils.js
+++ b/src/utils.js
@@ -117,8 +117,10 @@ export const normalizeData = function(data, baseUrl) {
     if (key === '@components') {
       data._components = {};
       for (const [key_, value_] of Object.entries(value)) {
-        data._components[key_] = normalizeData(value_, baseUrl);
-        data._components[key_]._path = data._path;
+        if (value_ !== null) {
+          data._components[key_] = normalizeData(value_, baseUrl);
+          data._components[key_]._path = data._path;
+        }
       }
       delete data[key];
     } else if (key === 'items' && value) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -54,9 +54,11 @@ export const normalizePath = path => {
 
 // Camelize
 export const normalizeType = type => {
-  type = type.replace(/(?:^\w|[A-Z]|\b\w)/g, function(letter) {
-    return letter.toUpperCase();
-  }).replace(/[\s\.]+/g, '');
+  type = type
+    .replace(/(?:^\w|[A-Z]|\b\w)/g, function(letter) {
+      return letter.toUpperCase();
+    })
+    .replace(/[\s\.]+/g, '');
   return type.startsWith('Plone') ? type : `Plone${type}`;
 };
 

--- a/tests/gatsby-starter-default/src/components/NavBar.js
+++ b/tests/gatsby-starter-default/src/components/NavBar.js
@@ -91,6 +91,9 @@ const mapDispatchToProps = dispatch => {
   };
 };
 
-const ConnectedNavBar = connect(mapStateToProps, mapDispatchToProps)(NavBar);
+const ConnectedNavBar = connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(NavBar);
 
 export default ConnectedNavBar;


### PR DESCRIPTION
This probably still needs test.

With some real legacy Plone data I run into issues with image fields having strange values. E.g. I found some kind of Photoshop pngs that worked well in Plone image scaling, but failed in Gatsby.

I figured out that defining the default image scale would make nice workaround. Using image scale would ensure that Plone always returns working image files (generated by Python imaging libraries in Plone) and it would also save some disk cache, because instead of possible huge originals the Gatsby build would only download scaled images big enough for the designed use.