### PR TITLE
Add ZPublisher compatible serialization for lists in searchParams

### DIFF
--- a/src/__tests__/utils.tests.js
+++ b/src/__tests__/utils.tests.js
@@ -10,6 +10,7 @@ import {
   parentId,
   parseHTMLtoReact,
   urlWithoutParameters,
+  serializeParams,
 } from '../utils';
 
 test('normalizeType normalizes and normalizeTypes content types', () => {
@@ -334,4 +335,27 @@ test('parseHTMLtoReact transforms relative links', async () => {
   expect(backlinks).toEqual(
     new Map([['/foobar/', ['/index/']], ['/foo/bar.png/', ['/index/']]])
   );
+});
+
+test('serialiseParams serialize paramas into ZPublisher format', () => {
+  expect(
+    serializeParams({
+      portal_type: 'Document',
+    })
+  ).toBe('portal_type=Document');
+  expect(
+    serializeParams({
+      portal_type: ['Document', 'Folder'],
+    })
+  ).toBe('portal_type%3Alist=Document&portal_type%3Alist=Folder');
+  expect(
+    serializeParams({
+      numeric_field: 42,
+    })
+  ).toBe('numeric_field%3Aint=42')
+  expect(
+    serializeParams({
+      numeric_field: 42,
+    })
+  ).toBe('numeric_field%3Aint=42')
 });

--- a/src/utils.js
+++ b/src/utils.js
@@ -76,6 +76,7 @@ export const fetchUrl = async (url, token, params, http = axios) => {
       token
     ),
     params: params,
+    paramsSerializer: serializeParams,
   });
   return response.data || {};
 };
@@ -187,4 +188,35 @@ export const parseHTMLtoReact = (html, baseUrl, path, backlinks) => {
   };
 
   return serialize(ReactHtmlParser(html, options));
+};
+
+export const serializeParams = params => {
+  let parts = [];
+
+  Object.entries(params).forEach(([key, val]) => {
+    if (val === null || typeof val === 'undefined') {
+      return;
+    }
+
+    if (Array.isArray(val)) {
+      key = key + ':list';
+    } else if (typeof val === 'number') {
+      key = key + ':int';
+      val = [val];
+    } else {
+      val = [val];
+    }
+
+    val.forEach(v => {
+      if (typeof v.getMonth === 'function') {
+        v = v.toISOString();
+      } else if (typeof v === 'object') {
+        // TODO: serialize into ZPublisher :record -format
+        v = JSON.stringify(v);
+      }
+      parts.push(encodeURIComponent(key) + '=' + encodeURIComponent(v));
+    });
+  });
+
+  return parts.join('&');
 };


### PR DESCRIPTION
No complete ZPublisher params serialization yet, but would make it possible to filter required content types with

```
searchParams: {
  portal_type: [
    'Document',
    'Folder',
  ]
}
```