### PR TITLE
Change to use Plone with websocket modification events

### DIFF
--- a/tests/gatsby-starter-default/docker-compose.yml
+++ b/tests/gatsby-starter-default/docker-compose.yml
@@ -1,6 +1,6 @@
 version: '3'
 services:
   api:
-    image: "kitconcept/plone.restapi:2.2.1"
+    image: "datakurre/gatsby-source-plone:2019-06-04"
     ports:
       - 8080:8080


### PR DESCRIPTION
This configures development environment to use custom Plone Docker image with websocket events available e.g. at baseUrl as defined in

https://github.com/collective/gatsby-source-plone/pull/176#issuecomment-496275066