### PR TITLE
chore: correct code block language tag in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ or
 
 Checkout sources from github:
 
-```bash:
+```bash
 git clone git@github.com:collective/gatsby-source-plone.git
 ```
 


### PR DESCRIPTION
This is to silence prism highlighter warnings. Thanks!